### PR TITLE
Remove nil pointing err reference

### DIFF
--- a/icsparser/daily.go
+++ b/icsparser/daily.go
@@ -41,13 +41,9 @@ func (c *Calendar) gatherRelevantEvents() DailyIngest {
 
 func (c *Calendar) PrepareDailyIngest() (map[string]string, error) {
 
-
-  var err error
-
   ingest := c.gatherRelevantEvents()
   if len(ingest.EventsToday) == 0 {
 
-    logger.Error(err.Error())
     return nil, errors.New("no events today")
 
   } else  {


### PR DESCRIPTION
err was never initialized, so referencing it lead to a segfault. It's also not necessary, so removing it should be save.